### PR TITLE
Issue 28 - Renamed categories to fit the CLI

### DIFF
--- a/src/types/codeclimbers.ts
+++ b/src/types/codeclimbers.ts
@@ -2,7 +2,7 @@ export namespace CodeClimbers {
   export interface Core {
     version: `${number}.${number}.${number}`;
     supportedBrowser: "edge" | "firefox" | "chrome";
-    category: "design" | "development" | "unknown" | "socialMedia";
+    category: "coding" | "designing" | "browsing" | "communication";
   }
 
   export interface Logging {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -44,6 +44,13 @@ export const SITES = {
     "hackernews.com",
     "x.com",
   ],
+  COMMUNICATION: [
+    "gmail.com",
+    "slack.com",
+    "discord.com",
+    "zoom.us",
+    "teams.microsoft.com",
+  ],
   GITHUB: [
     "https://github.com/",
     "https://gist.github.com/",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,16 +35,20 @@ export const getCategoryFromUrl = (
   url: string,
 ): CodeClimbers.Core["category"] => {
   if (SITES.DEV.some((site) => url.includes(site))) {
-    return "development";
+    return "coding";
   }
 
   if (SITES.DESIGN.some((site) => url.includes(site))) {
-    return "design";
+    return "designing";
   }
 
   if (SITES.SOCIAL_MEDIA.some((site) => url.includes(site))) {
-    return "socialMedia";
+    return "browsing";
   }
 
-  return "unknown";
+  if (SITES.COMMUNICATION.some((site) => url.includes(site))) {
+    return "communication";
+  }
+
+  return "browsing";
 };


### PR DESCRIPTION
## The Pull Request is ready

- [x] all github actions are passing
- [x] only a single issue was worked on
- [x] fixes #28
- [x] the branch follows the naming schema `issue-123-enable-x-does-not-disable-y`
- [x] the pull request has a sensible title

## Intention

With this change I intend to...
- Align categories with the categories from `app/components/Home/Time/CategoryChart` in the CLI

<!-- Please state what the intention of the change is -->

## Review Points

Please take extra care reviewing...
- Categories are right

<!-- Please list anything you want to have checked extra carefully -->

## The code follows best practices

- [x] duplicate code has been extracted where possible
- [x] issues for follow-up tasks have been created
- [x] tests have been written for any new functionality
- [x] there is no `any` type used
- [x] texts have been checked for grammar and spelling issues

## Notes

<!-- Use this section for any additional information you want to share -->
