### PR TITLE
Added a way to prevent duplicate heartbeats from firing off due to di…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 
 .env
+.DS_Store


### PR DESCRIPTION
…fferent loading patterns of websites

## The Pull Request is ready

- [x] all github actions are passing
- [x] only a single issue was worked on
- [x] fixes #31
- [x] the branch follows the naming schema `issue-123-enable-x-does-not-disable-y`
- [x] the pull request has a sensible title

## Intention

With this change I intend to...
- Do a quick fix to prevent multiple heart beats from wanting to fire off for the same event.
- This originates in three places: 
   - background:53
   - background:14
   - background:27

This happens due to different loading patterns; for example, Twitter will fire off two different "complete" events for its loading. 

<!-- Please state what the intention of the change is -->

## Review Points

Please take extra care reviewing...

<!-- Please list anything you want to have checked extra carefully -->

## The code follows best practices

- [x] duplicate code has been extracted where possible
- [x] issues for follow-up tasks have been created
- [x] tests have been written for any new functionality
- [x] there is no `any` type used
- [x] texts have been checked for grammar and spelling issues

## Notes

<!-- Use this section for any additional information you want to share -->
